### PR TITLE
update lock 2022 08 10

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658116816,
-        "narHash": "sha256-XCcuMBwGL7ief7qyovu0P8pkWlbIdCwRUXqyRjCrVU8=",
+        "lastModified": 1660156141,
+        "narHash": "sha256-LRUddGWx6GIEEIoF/SbRotFeX4n7J2CYkUnjepES3OA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e575199132c3c975f718ada1b0b8a744b0fb5186",
+        "rev": "ead1b9e47f9e2397da8f42da887ed416fc5762b5",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1657887110,
-        "narHash": "sha256-8VV0/kZed2z8fGtEc2zr+WLxTow+JTIlMjnSisyv0GQ=",
+        "lastModified": 1659978484,
+        "narHash": "sha256-VkErPc8pXcuFQG7jkkaUOEMORe81oweRNlAYZJ2+aRI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4c5106ed0f3168ff2df21b646aef67e86cbfc11c",
+        "rev": "c1addfdad3825f75a66f8d73ec7d2f68c78ba6f8",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1658125530,
-        "narHash": "sha256-cnudz2VaH59e0VUCRugJYnOSZcZAy5VEHNGpkGeXyJU=",
+        "lastModified": 1660163760,
+        "narHash": "sha256-H1+onwlTQJY9mjyqiUm4aTJWDANF59bLI8nzLhhX77s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "950a258b9ef24ca4346bbf722a694c2ab54e4654",
+        "rev": "77609c9034d53dd652d48e1ab1e27c1a088b33af",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1657886365,
-        "narHash": "sha256-S/fESi2Ba66h0HOwHHNQAPrNwMzGqEeYmp/lBK++Dxg=",
+        "lastModified": 1660146246,
+        "narHash": "sha256-yR/HXmAmNZVdBmx5h1LIJ/7lhu85I8muISJkshjTXjM=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "59764eb842d0da4f6fcf4ce4b85bf02ac1ae26fc",
+        "rev": "8f3fdef1e0cce2a5c6fc2e0740a069092f93e1da",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1655034179,
-        "narHash": "sha256-rf1/7AbzuYDw6+8Xvvf3PtEOygymLBrFsFxvext5ZjI=",
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "046ee4af7a9f016a364f8f78eeaa356ba524ac31",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1656782578,
-        "narHash": "sha256-1eMCBEqJplPotTo/SZ/t5HU6Sf2I8qKlZi9MX7jv9fw=",
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "573603b7fdb9feb0eb8efc16ee18a015c667ab1b",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
         "type": "github"
       },
       "original": {
@@ -388,11 +388,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1658015103,
-        "narHash": "sha256-mO+23f3SO+fBzEvbxRe6GkSB5Xp43CT2sV8Rs8MYdz8=",
+        "lastModified": 1659981942,
+        "narHash": "sha256-uCFiP/B/NXOWzhN6TKfMbSxtVMk1bVnCrnJRjCF6RmU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f485713f5e6b6883a9b6959afa98688360a3ecb",
+        "rev": "39d7f929fbcb1446ad7aa7441b04fb30625a4190",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -270,6 +270,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1660120254,
+        "narHash": "sha256-EMBa86JQ6W0och5Kxb1XmprgN/HFsSuJ9fRa2PtV3uk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e4c9d950a3c54a0760b127d406f6528eb625eed8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -345,6 +361,7 @@
         "nixos-vscode-server": "nixos-vscode-server",
         "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
         "statix": "statix",
         "unstable": "unstable"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs.nixpkgs-2105.url = "github:nixos/nixpkgs/nixos-21.05";
   inputs.nixpkgs-2111.url = "github:nixos/nixpkgs/nixos-21.11";
+  inputs.nixpkgs-2205.url = "github:nixos/nixpkgs/nixos-22.05";
   inputs.unstable.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.master.url = "github:nixos/nixpkgs/master";
 

--- a/home/configurations/nmelzer@enceladeus.nix
+++ b/home/configurations/nmelzer@enceladeus.nix
@@ -17,8 +17,6 @@
 
     enabledLanguages = ["cpp" "nix" "elixir" "erlang" "python"];
 
-    languages.python.useMS = true;
-
     programs.emacs.splashScreen = false;
 
     services.restic = {

--- a/home/configurations/nmelzer@mimas.nix
+++ b/home/configurations/nmelzer@mimas.nix
@@ -27,8 +27,6 @@
       "tex"
     ];
 
-    languages.python.useMS = true;
-
     programs.emacs.splashScreen = false;
 
     home.packages = let

--- a/home/modules/languages/python/default.nix
+++ b/home/modules/languages/python/default.nix
@@ -5,7 +5,7 @@ _: {
   ...
 }: let
   cfg = config.languages.python;
-  pyls = "${pkgs.python37Packages.python-language-server}/bin/pyls";
+  pyls = "${pkgs.python310Packages.python-lsp-server}/bin/pylsp";
   mspyls = "${pkgs.python-language-server}/bin/python-language-server";
 
   lsBin =

--- a/packages/advcp/default.nix
+++ b/packages/advcp/default.nix
@@ -4,13 +4,13 @@
   fetchpatch,
   upstream ? "coreutils",
 }:
-stdenv.mkDerivation (self: {
+stdenv.mkDerivation rec {
   name = "advcp";
   version = "8.30";
 
   src = fetchurl {
-    name = "source-${self.name}-${self.version}.tar.xz";
-    url = "ftp://ftp.gnu.org/gnu/${upstream}/${upstream}-${self.version}.tar.xz";
+    name = "source-${name}-${version}.tar.xz";
+    url = "ftp://ftp.gnu.org/gnu/${upstream}/${upstream}-${version}.tar.xz";
     sha256 = "0mxhw43d4wpqmvg0l4znk1vm10fy92biyh90lzdnqjcic2lb6cg8";
   };
 
@@ -25,4 +25,4 @@ stdenv.mkDerivation (self: {
     install -D src/cp $out/bin/advcp
     install -D src/mv $out/bin/advmv
   '';
-})
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -4,6 +4,7 @@
   ...
 } @ inputs: let
   pkgs = inputs.nixpkgs-2105.legacyPackages.x86_64-linux;
+  pkgs2205 = inputs.nixpkgs-2205.legacyPackages.x86_64-linux;
   upkgs = inputs.unstable.legacyPackages.x86_64-linux;
   mpkgs = inputs.master.legacyPackages.x86_64-linux;
 
@@ -13,7 +14,7 @@
   };
   nodePkgs = upkgs.callPackages ./nodePackages/override.nix {};
 in {
-  "advcp" = upkgs.callPackage ./advcp {};
+  "advcp" = pkgs2205.callPackage ./advcp {};
   "gnucash-de" = upkgs.callPackage ./gnucash-de {};
   "keyleds" = upkgs.callPackage ./keyleds {};
   "dracula/konsole" = upkgs.callPackage ./dracula/konsole {};


### PR DESCRIPTION
- flake.lock: Update
- fix: build advcp against 2205
- fix: use community forked pylsp instead of deprecated pyls
- fix: don't use MS python LS
