### PR TITLE
more clean enceladeus

### DIFF
--- a/home/configurations/nmelzer@enceladeus.nix
+++ b/home/configurations/nmelzer@enceladeus.nix
@@ -20,9 +20,7 @@
       "${pkgs.networkmanagerapplet}/bin/nm-applet"
     ];
 
-    enabledLanguages = ["cpp" "nix" "elixir" "erlang"];
-
-    programs.emacs.splashScreen = false;
+    programs.emacs.enable = lib.mkForce false;
 
     services.rustic = {
       enable = true;

--- a/home/modules/languages/default.nix
+++ b/home/modules/languages/default.nix
@@ -8,8 +8,10 @@ _: {
   in
     builtins.foldl' reducer {} config.enabledLanguages;
 in {
-  options.enabledLanguages =
-    lib.mkOption {type = lib.types.listOf lib.types.str;};
+  options.enabledLanguages = lib.mkOption {
+    default = [];
+    type = lib.types.listOf lib.types.str;
+  };
 
   config = {languages = langsEnabler;};
 }


### PR DESCRIPTION
- fix: have a default for enabled languages
- chore: remove emacs from enceladeus completely
