### PR TITLE
system backup redesign

### DIFF
--- a/nixos/configurations/mimas/restic.nix
+++ b/nixos/configurations/mimas/restic.nix
@@ -17,6 +17,7 @@
 
   extraPathes = [
     "/var/lib/nixos"
+    "/var/lib/redis-paperless"
   ];
 
   fileFromList = pkgs.writeText "files-from-verbatim" ''

--- a/nixos/configurations/mimas/restic.nix
+++ b/nixos/configurations/mimas/restic.nix
@@ -34,8 +34,8 @@
   mountCmds = lib.concatStringsSep "\n" (lib.mapAttrsToList (lv: _: "mount -o ro /dev/pool/${lv}_snap ${basePath}/${lv}") pools);
 
   unmountCmds = lib.concatStringsSep "\n" (lib.mapAttrsToList (lv: _: "umount ${basePath}/${lv}") pools);
-  lvdeactivates = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _: "lvs | grep -E '${name}\\s+.*a' || lvchange -an pool/${name}") snaps);
-  lvremoves = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _: "lvs | grep -E '${name}' || lvremove pool/${name}") snaps);
+  lvdeactivates = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _: "lvs | grep -E '${name}\\s+.*a' && lvchange -an pool/${name}") snaps);
+  lvremoves = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _: "lvs | grep -E '${name}' && lvremove pool/${name}") snaps);
 
   rest_repo = "rest:https://restic.mimas.internal.nobbz.dev/mimas";
   gdrv_repo = "/home/nmelzer/timmelzer@gmail.com/restic_repos/mimas";

--- a/nixos/configurations/mimas/restic.nix
+++ b/nixos/configurations/mimas/restic.nix
@@ -39,7 +39,6 @@
 
   rest_repo = "rest:https://restic.mimas.internal.nobbz.dev/mimas";
   gdrv_repo = "/home/nmelzer/timmelzer@gmail.com/restic_repos/mimas";
-  btwo_repo = "b2:nobbz-restic-services";
   pass = config.sops.secrets.restic.path;
 
   preStart = ''
@@ -144,15 +143,12 @@ in {
       eval $(cat "$CREDENTIALS_DIRECTORY/b2")
 
       restic copy --repo ${rest_repo} --repo2 ${gdrv_repo} -vvv
-      restic copy --repo ${rest_repo} --repo2 ${btwo_repo} -vvv
 
       restic forget --repo ${rest_repo} --keep-hourly 12 --keep-daily 4 --keep-weekly 3 --keep-monthly 7 --keep-yearly 10
       restic forget --repo ${gdrv_repo} --keep-daily 30 --keep-weekly 4 --keep-monthly 12 --keep-yearly 20
-      restic forget --repo ${btwo_repo} --keep-daily 30 --keep-weekly 4 --keep-monthly 12 --keep-yearly 20
 
       restic prune --repo ${rest_repo} --max-unused 0
       restic prune --repo ${gdrv_repo} --max-unused 0
-      restic prune --repo ${btwo_repo}
 
       chown -Rv nmelzer:users /home/nmelzer/timmelzer@gmail.com/restic_repos
     '';

--- a/nixos/configurations/mimas/restic.nix
+++ b/nixos/configurations/mimas/restic.nix
@@ -34,6 +34,7 @@
   mountCmds = lib.concatStringsSep "\n" (lib.mapAttrsToList (lv: _: "mount -o ro /dev/pool/${lv}_snap ${basePath}/${lv}") pools);
 
   unmountCmds = lib.concatStringsSep "\n" (lib.mapAttrsToList (lv: _: "umount ${basePath}/${lv}") pools);
+  uncheckedUnmountCmds = lib.concatStringsSep "\n" (lib.mapAttrsToList (lv: _: "umount ${basePath}/${lv} || true") pools);
   lvdeactivates = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _: "lvs | grep -E '${name}\\s+.*a' && lvchange -an pool/${name}") snaps);
   lvremoves = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _: "lvs | grep -E '${name}' && lvremove pool/${name}") snaps);
 
@@ -44,6 +45,8 @@
 
   preStart = ''
     set -x
+
+    ${uncheckedUnmountCmds}
 
     ${lvdeactivates}
     ${lvremoves}

--- a/nixos/configurations/mimas/restic.nix
+++ b/nixos/configurations/mimas/restic.nix
@@ -6,7 +6,7 @@
 }: let
   resticPort = 9999;
 
-  inherit (pkgs) writeShellScript proot mount umount restic;
+  inherit (pkgs) proot mount umount restic;
 
   pools = {
     gitea = "/var/lib/gitea";
@@ -20,12 +20,7 @@
     "/var/lib/redis-paperless"
   ];
 
-  fileFromList = pkgs.writeText "files-from-verbatim" ''
-    ${lib.concatStringsSep "\n" pathes}
-  '';
-
   basePath = "/tmp/backup";
-  pathes = extraPathes ++ builtins.attrValues pools;
   mounts = lib.flatten (
     (lib.mapAttrsToList (lv: path: ["-b" "${basePath}/${lv}:${path}"]) pools)
     ++ (builtins.map (path: ["-b" "${path}:${path}"]) extraPathes)


### PR DESCRIPTION
- refactor: use post/pre for proper failsafe mount/unmount
- fix: logical error
- refactor: make scripts inheritable
- fix: make sure everything is unmounted before backup
- chore: add more to backup
- refactor: use chroot-style proot
- chore: remove unused bindings
- chore: remove b2 backend from restic for now
