### PR TITLE
Remove check warnings

### DIFF
--- a/nixos/configurations/bootloader/enceladeus.nix
+++ b/nixos/configurations/bootloader/enceladeus.nix
@@ -3,7 +3,6 @@
 
   # Use the GRUB 2 boot loader.
   boot.loader.grub.enable = true;
-  boot.loader.grub.version = 2;
   boot.loader.grub.useOSProber = false;
 
   # boot.loader.grub.efiSupport = true;

--- a/nixos/configurations/mimas.nix
+++ b/nixos/configurations/mimas.nix
@@ -162,16 +162,16 @@ in {
 
   services.gitea = {
     enable = true;
-    httpAddress = "127.0.0.1";
-    domain = "gitea.mimas.internal.nobbz.dev";
+    settings.server.DOMAIN = "gitea.mimas.internal.nobbz.dev";
+    settings.server.HTTP_ADDR = "127.0.0.1";
     settings.server.ROOT_URL = lib.mkForce "https://gitea.mimas.internal.nobbz.dev/";
     settings."git.timeout".DEFAULT = 3600; # 1 hour
     settings."git.timeout".MIGRATE = 3600; # 1 hour
     settings."git.timeout".MIRROR = 3600; # 1 hour
     settings."git.timeout".CLONE = 3600; # 1 hour
     settings."git.timeout".PULL = 3600; # 1 hour
-    settings."git.timeout".GC = 3600;
-  }; # 1 hour
+    settings."git.timeout".GC = 3600; # 1 hour
+  };
   systemd.services.gitea.after = ["var-lib-gitea.mount"];
 
   virtualisation = {
@@ -338,7 +338,7 @@ in {
       fritz.loadBalancer.servers = [{url = "http://fritz.box";}];
 
       gitea.loadBalancer.passHostHeader = true;
-      gitea.loadBalancer.servers = [{url = "http://localhost:${toString config.services.gitea.httpPort}";}];
+      gitea.loadBalancer.servers = [{url = "http://localhost:${toString config.services.gitea.settings.server.HTTP_PORT}";}];
 
       grafana.loadBalancer.passHostHeader = true;
       grafana.loadBalancer.servers = [{url = "http://localhost:${toString config.services.grafana.settings.server.http_port}";}];

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -37,7 +37,7 @@
 
         advcp = upkgs.callPackage ./advcp {};
         "dracula/konsole" = upkgs.callPackage ./dracula/konsole {};
-        emacs = epkgs.emacsUnstable;
+        emacs = epkgs.emacs-unstable;
         "rofi/unicode" = upkgs.callPackage ./rofi-unicode {};
         "zx" = upkgs.nodePackages.zx;
 

--- a/parts/system_configs.nix
+++ b/parts/system_configs.nix
@@ -86,7 +86,7 @@ in {
 
           finalModules =
             [
-              {boot.cleanTmpDir = true;}
+              {boot.tmp.cleanOnBoot = true;}
               {networking.hostName = name;}
               {nix.flakes.enable = true;}
               {system.configurationRevision = self.rev or "dirty";}


### PR DESCRIPTION
- fix: deprecation of boot.cleanTmpDir
- fix: deprecation of service.gitea children
- fix: deprecation of grub.version
- fixup! fix: deprecation of service.gitea children
- fix: rename emacsUnstable
