### PR TITLE
update 2023 12 11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701106761,
-        "narHash": "sha256-hEjYEdzc7Y1tJbYs8nT+svxH/VdmeJLjWR8oX46IMp8=",
+        "lastModified": 1702287671,
+        "narHash": "sha256-4kfBKhcZGX7RemWdi6grwIFla8HrKTiz4jSqvgAtDjU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ff495a3172537a9a5d05fadd0699daf5deb48dc0",
+        "rev": "5075b8df3d8d4d28e73e921acb46a2cf7f34ad28",
         "type": "github"
       },
       "original": {
@@ -209,11 +209,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -364,11 +364,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701071203,
-        "narHash": "sha256-lQywA7QU/vzTdZ1apI0PfgCWNyQobXUYghVrR5zuIeM=",
+        "lastModified": 1702203126,
+        "narHash": "sha256-4BhN2Vji19MzRC7SUfPZGmtZ2WZydQeUk/ogfRBIZMs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
+        "rev": "defbb9c5857e157703e8fc7cf3c2ceb01cb95883",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1701137035,
-        "narHash": "sha256-oNQvwySTQcDqXdRQGxNsbqbyF7U8hZl4YQv5TRbJRDk=",
+        "lastModified": 1702288598,
+        "narHash": "sha256-9ZgWXjw3Jsi/sbhnmdQbalq/Wn9/islMtYVjeNNQr1A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "337f0451e8a0d275d4586fd69e686213d2a85ea4",
+        "rev": "69d61d5ab0500d9ee52881ebacfb8c8f268ca0d8",
         "type": "github"
       },
       "original": {
@@ -447,11 +447,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1701058231,
-        "narHash": "sha256-OdvHzqZK2JUn7Ao7hZImZmgOBRYZwWy/MYQCFFjITDg=",
+        "lastModified": 1701225372,
+        "narHash": "sha256-QSiFeEmTzAIIiCtUaMesu7wi7bvfHuFzPMQpOKMt4Lo=",
         "owner": "oxalica",
         "repo": "nil",
-        "rev": "1348b53085d3befd86b39cf15dc00702af3e5a79",
+        "rev": "0031eb4343fd4672742fd6ff839da9b4f5120646",
         "type": "github"
       },
       "original": {
@@ -469,11 +469,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1701102321,
-        "narHash": "sha256-HxA+DETsbnvg5qq/GvDlxo/ooTMijVpnzI13Is25bNQ=",
+        "lastModified": 1702262555,
+        "narHash": "sha256-K9lQPMsKgMIH+WhwogsL5dfWK3Gd7+P1mP5hSB7budk=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "f0180487a0e4c0091b46cb1469c44144f5400240",
+        "rev": "5c917c32048ef185ea0eec352c3505485aa3212c",
         "type": "github"
       },
       "original": {
@@ -568,11 +568,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1698611440,
-        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
         "type": "github"
       },
       "original": {
@@ -601,11 +601,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1700989516,
-        "narHash": "sha256-oKbmPa2wpTHh9XB3+zIx97uMZGNnp97GPliKKG2/plo=",
+        "lastModified": 1701805708,
+        "narHash": "sha256-hh0S14E816Img0tPaNQSEKFvSscSIrvu1ypubtfh6M4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2e4de209881b38392933fabf303cde3454b0b4c",
+        "rev": "0561103cedb11e7554cf34cea81e5f5d578a4753",
         "type": "github"
       },
       "original": {
@@ -617,11 +617,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1700905716,
-        "narHash": "sha256-w1vHn2MbGfdC+CrP3xLZ3scsI06N0iQLU7eTHIVEFGw=",
+        "lastModified": 1702148972,
+        "narHash": "sha256-h2jODFP6n+ABrUWcGRSVPRFfLOkM9TJ2pO+h+9JcaL0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb95385d21475da10b63da74ae96d89ab352431",
+        "rev": "b8f33c044e51de6dde3ad80a9676945e0e4e3227",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1700794826,
-        "narHash": "sha256-RyJTnTNKhO0yqRpDISk03I/4A67/dp96YRxc86YOPgU=",
+        "lastModified": 1702151865,
+        "narHash": "sha256-9VAt19t6yQa7pHZLDbil/QctAgVsA66DLnzdRGqDisg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8",
+        "rev": "666fc80e7b2afb570462423cb0e1cf1a3a34fedd",
         "type": "github"
       },
       "original": {
@@ -680,16 +680,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1700748986,
-        "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
+        "lastModified": 1701355166,
+        "narHash": "sha256-4V7XMI0Gd+y0zsi++cEHd99u3GNL0xSTGRmiWKzGnUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ba29e2346bc542e9909d1021e8fd7d4b3f64db0",
+        "rev": "36c4ac09e9bebcec1fa7b7539cddb0c9e837409c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05-small",
+        "ref": "staging-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -710,11 +710,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1700856099,
-        "narHash": "sha256-RnEA7iJ36Ay9jI0WwP+/y4zjEhmeN6Cjs9VOFBH7eVQ=",
+        "lastModified": 1702029940,
+        "narHash": "sha256-qM3Du0perpLesh5hr87mVPZ79McMUKIWUH7EQMh2kWo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bd59c54ef06bc34eca01e37d689f5e46b3fe2f1",
+        "rev": "e9ef8a102c555da4f8f417fe5cf5bd539d8a38b7",
         "type": "github"
       },
       "original": {
@@ -745,11 +745,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1698882062,
-        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
         "type": "github"
       },
       "original": {
@@ -810,11 +810,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1701116159,
-        "narHash": "sha256-gVRoedJ46D4UPEubQyJIAqHqhGDzJbEKD8hAGGKufWM=",
+        "lastModified": 1702273340,
+        "narHash": "sha256-q7NrsSG9pfX9erbeY3fdE92qFp6omr6XSZc1x0HvgW0=",
         "owner": "wamserma",
         "repo": "flake-programs-sqlite",
-        "rev": "ecb8474d2908a3265cffcdc14bc73a2dda2db8e4",
+        "rev": "7fe8166208b5350e5e6542177a692f33717aaf71",
         "type": "github"
       },
       "original": {
@@ -935,11 +935,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1701127353,
-        "narHash": "sha256-qVNX0wOl0b7+I35aRu78xUphOyELh+mtUp1KBx89K1Q=",
+        "lastModified": 1702177193,
+        "narHash": "sha256-J2409SyXROoUHYXVy9h4Pj0VU8ReLuy/mzBc9iK4DBg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b1edbf5c0464b4cced90a3ba6f999e671f0af631",
+        "rev": "d806e546f96c88cd9f7d91c1c19ebc99ba6277d9",
         "type": "github"
       },
       "original": {

--- a/home/configurations/default.nix
+++ b/home/configurations/default.nix
@@ -4,6 +4,7 @@ _: {
   nobbz.homeConfigurations."nmelzer@mimas".system = "x86_64-linux";
   nobbz.homeConfigurations."nmelzer@enceladeus".system = "x86_64-linux";
   nobbz.homeConfigurations."nmelzer@hyperion".system = "aarch64-linux";
+  nobbz.homeConfigurations."nmelzer@janus".enable = false;
   nobbz.homeConfigurations."nmelzer@janus".system = "x86_64-linux";
   nobbz.homeConfigurations."nmelzer@phoebe".system = "x86_64-linux";
 

--- a/home/configurations/nmelzer_at_mimas.nix
+++ b/home/configurations/nmelzer_at_mimas.nix
@@ -33,10 +33,13 @@
         inherit (config.nixpkgs) config;
         inherit (pkgs) system;
       };
+
+      obsidian = pkgs.obsidian.override { electron = pkgs.electron_27; };
     in
       builtins.attrValues {
         inherit (pkgs) keybase-gui freerdp keepassxc nix-output-monitor discord;
-        inherit (pkgs) obsidian;
+        # inherit (pkgs) obsidian;
+        inherit obsidian;
         inherit (pkgs.gnome) gnome-tweaks;
         # https://nixpk.gs/pr-tracker.html?pr=248167
         # ^^ once in unstable, revert this commit ^^

--- a/home/configurations/nmelzer_at_mimas.nix
+++ b/home/configurations/nmelzer_at_mimas.nix
@@ -13,6 +13,7 @@
   config = {
     nixpkgs.allowedUnfree = ["google-chrome" "vscode" "discord" "obsidian"];
     nixpkgs.config.allowBroken = true;
+    nixpkgs.config.permittedInsecurePackages = ["electron-25.9.0"];
 
     activeProfiles = ["browsing" "development"];
 
@@ -33,13 +34,10 @@
         inherit (config.nixpkgs) config;
         inherit (pkgs) system;
       };
-
-      obsidian = pkgs.obsidian.override { electron = pkgs.electron_27; };
     in
       builtins.attrValues {
         inherit (pkgs) keybase-gui freerdp keepassxc nix-output-monitor discord;
-        # inherit (pkgs) obsidian;
-        inherit obsidian;
+        inherit (pkgs) obsidian;
         inherit (pkgs.gnome) gnome-tweaks;
         # https://nixpk.gs/pr-tracker.html?pr=248167
         # ^^ once in unstable, revert this commit ^^

--- a/home/configurations/nmelzer_at_phoebe.nix
+++ b/home/configurations/nmelzer_at_phoebe.nix
@@ -10,6 +10,7 @@ in {
   _file = ./nmelzer_at_phoebe.nix;
 
   nixpkgs.allowedUnfree = ["google-chrome" "vscode" "discord" "obsidian" "slack"];
+  nixpkgs.config.permittedInsecurePackages = ["electron-25.9.0"];
 
   activeProfiles = ["development"];
 


### PR DESCRIPTION
- flake.lock: Update
- fix: use newer secure electron for obsidian on mimas
