### PR TITLE
update 2024 02 28

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1709024751,
-        "narHash": "sha256-G6ZB1QsFzGgcYQNjOSLYRKmhXf/4b6ldY+1oCGQc3I4=",
+        "lastModified": 1709111166,
+        "narHash": "sha256-PgTs0tyjisRkzBGv8VbsTwT6UWWRfkpZNdhvWvXImk0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c94a9019370b0d719621e1478d5bb317223ec15b",
+        "rev": "119523b8931aaad7648e1e42fe653f66a9b5ee21",
         "type": "github"
       },
       "original": {
@@ -286,11 +286,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1709025000,
-        "narHash": "sha256-1SeIoszHiDhIgfqVFfGz0QN56lrVd/OAgH9+hxJAXQc=",
+        "lastModified": 1709115132,
+        "narHash": "sha256-/4N1LRPNQXLXjhzMX3pT0VbrpodtZWlSUuHYNiHoui0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6212b787b8db7f03dfb48de3c493b58b0d1caa93",
+        "rev": "41194c12410a9b7022a6d03de0f7e63b32e81f03",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1708975558,
-        "narHash": "sha256-u+MvOraksz28KJRerd5jMC6R/HHfvW1vIDkyrXnSyQY=",
+        "lastModified": 1709078542,
+        "narHash": "sha256-H4328a0YR6S3f34mWww8NO49+Pt76ts/Xz0lm6vPZv8=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "4c7f0ef6cac4fddbbbcc3ef9304aa77786f9ef17",
+        "rev": "f489a6e42d2ad3e7b8a8c28f2c3f52452c8b081a",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708831307,
-        "narHash": "sha256-0iL/DuGjiUeck1zEaL+aIe2WvA3/cVhp/SlmTcOZXH4=",
+        "lastModified": 1708979614,
+        "narHash": "sha256-FWLWmYojIg6TeqxSnHkKpHu5SGnFP5um1uUjH+wRV6g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b",
+        "rev": "b7ee09cf5614b02d289cd86fcfa6f24d4e078c2a",
         "type": "github"
       },
       "original": {
@@ -476,11 +476,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1708807242,
-        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "lastModified": 1708984720,
+        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
         "type": "github"
       },
       "original": {
@@ -594,11 +594,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1708999689,
-        "narHash": "sha256-2FwYIWAnb+XeSCwfcmRd7I6a7U87hp9Vc8lMhQA1TOk=",
+        "lastModified": 1709073760,
+        "narHash": "sha256-ZdwWuN7q1UOMy8dsuNPrGgdOpBaHijGnnsDkohgisS4=",
         "owner": "wamserma",
         "repo": "flake-programs-sqlite",
-        "rev": "b17630a859ed3c9c03a681edb7fd6a5059077952",
+        "rev": "eab5c58d2f3eda2ce155f5d47a719947d69d40be",
         "type": "github"
       },
       "original": {

--- a/nixos/modules/kernel.nix
+++ b/nixos/modules/kernel.nix
@@ -4,7 +4,11 @@ _: {
   config,
   ...
 }: let
-  zfsUsed = lib.lists.elem "zfs" (config.boot.supportedFilesystems ++ config.boot.initrd.supportedFilesystems);
+  supportedFilesystems =
+    if builtins.isList config.boot.supportedFilesystems
+    then config.boot.supportedFilesystems ++ config.boot.initrd.supportedFilesystems
+    else builtins.attrNames (lib.filterAttrs (_name: value: value) (config.boot.supportedFilesystems // config.boot.initrd.supportedFilesystems));
+  zfsUsed = lib.lists.elem "zfs" supportedFilesystems;
 in {
   _file = ./kernel.nix;
 

--- a/parts/system_configs.nix
+++ b/parts/system_configs.nix
@@ -89,7 +89,7 @@ in {
               {boot.tmp.cleanOnBoot = true;}
               {networking.hostName = name;}
               {nix.flakes.enable = true;}
-              {system.configurationRevision = self.rev or "${self.dirtyRev}-dirty";}
+              {system.configurationRevision = self.rev or "${self.dirtyRev or "unknown"}-dirty";}
               {documentation.man.enable = true;}
               {documentation.man.generateCaches = true;}
               {nixpkgs.hostPlatform.system = config.system;}


### PR DESCRIPTION
- flake.lock: Update
- fall back if dirtyRev is unknown
- make zfs-check work with old style list and newstyle set
