### PR TITLE
clean inputs

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,5 +1,5 @@
 inputs: let
-  pkgs = inputs.unstable.legacyPackages.x86_64-linux;
+  pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
   apkgs = inputs.alejandra.packages.x86_64-linux;
 
   callPackage = pkgs.lib.callPackageWith (pkgs // apkgs // {inherit (inputs) self;});

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,8 +1,7 @@
 inputs: let
   pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
-  apkgs = inputs.alejandra.packages.x86_64-linux;
 
-  callPackage = pkgs.lib.callPackageWith (pkgs // apkgs // {inherit (inputs) self;});
+  callPackage = pkgs.lib.callPackageWith (pkgs // {inherit (inputs) self;});
 in {
   alejandra = callPackage ./alejandra.nix {};
   statix = callPackage ./statix.nix {};

--- a/flake.lock
+++ b/flake.lock
@@ -52,7 +52,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": [
-          "master"
+          "nixpkgs"
         ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
@@ -317,22 +317,6 @@
       "original": {
         "owner": "libgit2",
         "repo": "libgit2",
-        "type": "github"
-      }
-    },
-    "master": {
-      "locked": {
-        "lastModified": 1719261889,
-        "narHash": "sha256-9Vn7gjC7f1nxjPor1e+0/9iH4quvoJvb/qIQ27ik1NQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3d15d3b837ce4b14f91ced705f4a83f50df54b3e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "master",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -734,7 +718,6 @@
         "emacs": "emacs",
         "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
-        "master": "master",
         "nil": "nil",
         "nix": "nix",
         "nixos-vscode-server": "nixos-vscode-server",

--- a/flake.lock
+++ b/flake.lock
@@ -81,27 +81,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -228,7 +207,9 @@
     "nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
+        "flake-parts": [
+          "parts"
+        ],
         "libgit2": "libgit2",
         "nixpkgs": "nixpkgs",
         "nixpkgs-23-11": "nixpkgs-23-11",
@@ -457,7 +438,9 @@
     "nvim": {
       "inputs": {
         "nixpkgs": "nixpkgs_4",
-        "parts": "parts"
+        "parts": [
+          "parts"
+        ]
       },
       "locked": {
         "lastModified": 1719171354,
@@ -474,27 +457,6 @@
       }
     },
     "parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "parts_2": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
@@ -574,7 +536,7 @@
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-insync-v3": "nixpkgs-insync-v3",
         "nvim": "nvim",
-        "parts": "parts_2",
+        "parts": "parts",
         "programsdb": "programsdb",
         "sops-nix": "sops-nix",
         "switcher": "switcher"

--- a/flake.lock
+++ b/flake.lock
@@ -525,16 +525,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1716769173,
-        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "alejandra": {
-      "inputs": {
-        "fenix": "fenix",
-        "flakeCompat": "flakeCompat",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1660592437,
-        "narHash": "sha256-xFumnivtVwu5fFBOrTxrv6fv3geHKF04RGP23EsDVaI=",
-        "owner": "kamadorueda",
-        "repo": "alejandra",
-        "rev": "e7eac49074b70814b542fee987af2987dd0520b5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kamadorueda",
-        "ref": "3.0.0",
-        "repo": "alejandra",
-        "type": "github"
-      }
-    },
     "cargo2nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
@@ -67,28 +46,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "alejandra",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1657607339,
-        "narHash": "sha256-HaqoAwlbVVZH2n4P3jN2FFPMpVuhxDy1poNOR7kzODc=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "b814c83d9e6aa5a28d0cf356ecfdafb2505ad37d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
         "type": "github"
       }
     },
@@ -232,22 +189,6 @@
         "type": "github"
       }
     },
-    "flakeCompat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -289,7 +230,7 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "libgit2": "libgit2",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression",
         "pre-commit-hooks": "pre-commit-hooks"
@@ -311,7 +252,7 @@
     "nixos-vscode-server": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1713958148,
@@ -329,16 +270,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657425264,
-        "narHash": "sha256-3aHvoI2e8vJKw3hvnHECaBpSsL5mxVsVtaLCnTdNcH8=",
-        "owner": "nixos",
+        "lastModified": 1717432640,
+        "narHash": "sha256-+f9c4/ZX5MWDOuB1rKoWj+lBNm0z0rs4CK47HBLxy1o=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "de5b3dd17034e6106e75746e81618e5bd408de8a",
+        "rev": "88269ab3044128b7c2f4c7d68448b2fb50456870",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable-small",
+        "owner": "NixOS",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -437,22 +378,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717432640,
-        "narHash": "sha256-+f9c4/ZX5MWDOuB1rKoWj+lBNm0z0rs4CK47HBLxy1o=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "88269ab3044128b7c2f4c7d68448b2fb50456870",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1682134069,
         "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
         "owner": "NixOS",
@@ -465,7 +390,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1719075281,
         "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
@@ -481,7 +406,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1718606988,
         "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
@@ -497,7 +422,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1718983919,
         "narHash": "sha256-+1xgeIow4gJeiwo4ETvMRvWoircnvb0JOt7NS9kUhoM=",
@@ -513,7 +438,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1681358109,
         "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
@@ -531,7 +456,7 @@
     },
     "nvim": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "parts": "parts"
       },
       "locked": {
@@ -642,12 +567,11 @@
     },
     "root": {
       "inputs": {
-        "alejandra": "alejandra",
         "emacs": "emacs",
         "home-manager": "home-manager",
         "nix": "nix",
         "nixos-vscode-server": "nixos-vscode-server",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-insync-v3": "nixpkgs-insync-v3",
         "nvim": "nvim",
         "parts": "parts_2",
@@ -656,27 +580,10 @@
         "switcher": "switcher"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1657557289,
-        "narHash": "sha256-PRW+nUwuqNTRAEa83SfX+7g+g8nQ+2MMbasQ9nt6+UM=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "caf23f29144b371035b864a1017dbc32573ad56d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1687746941,
@@ -694,7 +601,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {

--- a/flake.lock
+++ b/flake.lock
@@ -24,7 +24,7 @@
     "cargo2nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "switcher",
           "nixpkgs"
@@ -182,24 +182,6 @@
       }
     },
     "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -214,9 +196,9 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -232,9 +214,9 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_5": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -250,9 +232,9 @@
         "type": "github"
       }
     },
-    "flake-utils_7": {
+    "flake-utils_6": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -320,32 +302,12 @@
         "type": "github"
       }
     },
-    "nil": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1717086091,
-        "narHash": "sha256-GmsEQa4HZeMfec37LZnwG/Lt/XmqFLXsjv5QWojeNiM=",
-        "owner": "oxalica",
-        "repo": "nil",
-        "rev": "ab3ddb8f063774cf7e22eb610f5ecfdb77309f3c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "nil",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "libgit2": "libgit2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression",
         "pre-commit-hooks": "pre-commit-hooks"
@@ -366,8 +328,8 @@
     },
     "nixos-vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1713958148,
@@ -493,22 +455,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716977081,
-        "narHash": "sha256-pFe5jLeIPlKEln5n2h998d7cpzXFdbrBMRe3suz4K1o=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ac82a513e55582291805d6f09d35b6d8b60637a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1717432640,
         "narHash": "sha256-+f9c4/ZX5MWDOuB1rKoWj+lBNm0z0rs4CK47HBLxy1o=",
         "owner": "NixOS",
@@ -523,7 +469,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1682134069,
         "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
@@ -537,7 +483,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1719075281,
         "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
@@ -553,7 +499,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1718606988,
         "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
@@ -569,7 +515,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1718983919,
         "narHash": "sha256-+1xgeIow4gJeiwo4ETvMRvWoircnvb0JOt7NS9kUhoM=",
@@ -585,7 +531,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1681358109,
         "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
@@ -603,7 +549,7 @@
     },
     "nvim": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "parts": "parts"
       },
       "locked": {
@@ -664,7 +610,7 @@
         "flake-compat": [
           "nix"
         ],
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "gitignore": [
           "nix"
         ],
@@ -718,10 +664,9 @@
         "emacs": "emacs",
         "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
-        "nil": "nil",
         "nix": "nix",
         "nixos-vscode-server": "nixos-vscode-server",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-insync-v3": "nixpkgs-insync-v3",
         "nvim": "nvim",
         "parts": "parts_2",
@@ -749,33 +694,8 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "nil",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nil",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717035469,
-        "narHash": "sha256-MzH+yjKULH3HCRj9QCTwBvqq4LZkR0ZqRE/QfGOGC2E=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "095702e63a40e86f339d11864da9dc965b70a01e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_8"
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1687746941,
@@ -793,7 +713,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
@@ -819,7 +739,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_2"
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
         "lastModified": 1707998256,
@@ -897,21 +817,6 @@
       }
     },
     "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_6": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -415,22 +415,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-23-11": {
       "locked": {
         "lastModified": 1717159533,
@@ -757,16 +741,12 @@
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-insync-v3": "nixpkgs-insync-v3",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nvim": "nvim",
         "parts": "parts_2",
         "programsdb": "programsdb",
         "sops-nix": "sops-nix",
-        "stable": [
-          "nixpkgs-2211"
-        ],
         "switcher": "switcher",
         "unstable": [
           "nixpkgs-unstable"

--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,7 @@
     "cargo2nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "switcher",
           "nixpkgs"
@@ -33,7 +33,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1719245815,
@@ -119,24 +121,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
         "lastModified": 1694529238,
         "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
@@ -150,9 +134,9 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -211,7 +195,9 @@
           "parts"
         ],
         "libgit2": "libgit2",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression",
         "pre-commit-hooks": "pre-commit-hooks"
@@ -232,8 +218,13 @@
     },
     "nixos-vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": [
+          "emacs",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1713958148,
@@ -251,16 +242,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717432640,
-        "narHash": "sha256-+f9c4/ZX5MWDOuB1rKoWj+lBNm0z0rs4CK47HBLxy1o=",
-        "owner": "NixOS",
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88269ab3044128b7c2f4c7d68448b2fb50456870",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -327,22 +318,6 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1719122173,
-        "narHash": "sha256-aEMsNUtqSPwn6l+LIZ/rX++nCgun3E9M3uSZs6Rwb7w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "906320ae02f769d13a646eb3605a9821df0d6ea2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable_2": {
-      "locked": {
         "lastModified": 1719099622,
         "narHash": "sha256-YzJECAxFt+U5LPYf/pCwW/e1iUd2PF21WITHY9B/BAs=",
         "owner": "NixOS",
@@ -359,36 +334,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1682134069,
-        "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fd901ef4bf93499374c5af385b2943f5801c0833",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1718606988,
         "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
         "owner": "nixos",
@@ -403,7 +348,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1718983919,
         "narHash": "sha256-+1xgeIow4gJeiwo4ETvMRvWoircnvb0JOt7NS9kUhoM=",
@@ -419,7 +364,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1681358109,
         "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
@@ -437,7 +382,7 @@
     },
     "nvim": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_2",
         "parts": [
           "parts"
         ]
@@ -533,7 +478,7 @@
         "home-manager": "home-manager",
         "nix": "nix",
         "nixos-vscode-server": "nixos-vscode-server",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-insync-v3": "nixpkgs-insync-v3",
         "nvim": "nvim",
         "parts": "parts",
@@ -544,8 +489,8 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_6"
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1687746941,
@@ -563,8 +508,8 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5",
-        "nixpkgs-stable": "nixpkgs-stable_2"
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
         "lastModified": 1719111739,
@@ -637,21 +582,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -24,7 +24,7 @@
     "cargo2nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "switcher",
           "nixpkgs"
@@ -164,24 +164,6 @@
       }
     },
     "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -196,9 +178,9 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_3": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -214,9 +196,9 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -232,9 +214,9 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_5": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -328,7 +310,7 @@
     },
     "nixos-vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
@@ -610,7 +592,7 @@
         "flake-compat": [
           "nix"
         ],
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "gitignore": [
           "nix"
         ],
@@ -662,7 +644,6 @@
       "inputs": {
         "alejandra": "alejandra",
         "emacs": "emacs",
-        "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
         "nix": "nix",
         "nixos-vscode-server": "nixos-vscode-server",
@@ -694,7 +675,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
@@ -802,21 +783,6 @@
       }
     },
     "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_5": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719193216,
-        "narHash": "sha256-4jggHHDsLt+i4/6lMNlZkHd3bzgV50feNpZGe4X3eMQ=",
+        "lastModified": 1719245815,
+        "narHash": "sha256-BiDNkoh9a2dx2OTUFpzWhkGq5WfatG7sUX4Kw0Fdo7g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e3e9ef4c9904fddbd8c00f3288e6a3be26a6bf0b",
+        "rev": "b6082d10feac69203dac419818daa47c5fe36464",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1719195213,
-        "narHash": "sha256-dwi6Ks3pDkrjwp6kgRw8mryvGIhLbsd0sfsIulFXhRI=",
+        "lastModified": 1719261889,
+        "narHash": "sha256-9Vn7gjC7f1nxjPor1e+0/9iH4quvoJvb/qIQ27ik1NQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f3e3fe79ae98179b830cdfbbf8fc8a7cdda6e06b",
+        "rev": "3d15d3b837ce4b14f91ced705f4a83f50df54b3e",
         "type": "github"
       },
       "original": {
@@ -367,11 +367,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1719194950,
-        "narHash": "sha256-ymnWoyiiJEFnlkGJWdZ/FS2JsPkIw9K0vqH7uP3QdDM=",
+        "lastModified": 1719250573,
+        "narHash": "sha256-4570TzNpOwcJ0O4KPjCqFhEKNRXJzJxu8cDvvoeTHw0=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "927b719bce3b586454766fce7d8ed45c32cce14b",
+        "rev": "5c497a992bfdaf63d1af5ac76235a2a383cb63c9",
         "type": "github"
       },
       "original": {
@@ -493,11 +493,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718811006,
-        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "lastModified": 1719122173,
+        "narHash": "sha256-aEMsNUtqSPwn6l+LIZ/rX++nCgun3E9M3uSZs6Rwb7w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "rev": "906320ae02f769d13a646eb3605a9821df0d6ea2",
         "type": "github"
       },
       "original": {
@@ -525,16 +525,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "lastModified": 1716769173,
+        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -731,11 +731,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1719152096,
-        "narHash": "sha256-fZ4sVSY1khq2IZvdVyVbR15+xbqG/0EX51RMBOMbNMc=",
+        "lastModified": 1719244340,
+        "narHash": "sha256-PIPjZqRpGXyUTbEpAWkdVqP2Phwg/bO/xB9yCv4rj/U=",
         "owner": "wamserma",
         "repo": "flake-programs-sqlite",
-        "rev": "9db2b43c0fd8b475cbbc0e5b75c689c2bda1be73",
+        "rev": "82fb3732d450f15644ae214a3c134b04ed4b4e2a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -287,7 +287,7 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "unstable"
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -491,22 +491,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1716977081,
@@ -555,6 +539,22 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1718606988,
         "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
         "owner": "nixos",
@@ -569,7 +569,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1718983919,
         "narHash": "sha256-+1xgeIow4gJeiwo4ETvMRvWoircnvb0JOt7NS9kUhoM=",
@@ -585,7 +585,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1681358109,
         "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
@@ -603,7 +603,7 @@
     },
     "nvim": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_6",
         "parts": "parts"
       },
       "locked": {
@@ -694,7 +694,7 @@
     "programsdb": {
       "inputs": {
         "nixpkgs": [
-          "unstable"
+          "nixpkgs"
         ],
         "utils": "utils"
       },
@@ -721,19 +721,13 @@
         "nil": "nil",
         "nix": "nix",
         "nixos-vscode-server": "nixos-vscode-server",
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ],
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-insync-v3": "nixpkgs-insync-v3",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "nvim": "nvim",
         "parts": "parts_2",
         "programsdb": "programsdb",
         "sops-nix": "sops-nix",
-        "switcher": "switcher",
-        "unstable": [
-          "nixpkgs-unstable"
-        ]
+        "switcher": "switcher"
       }
     },
     "rust-analyzer-src": {
@@ -781,7 +775,7 @@
     "rust-overlay_2": {
       "inputs": {
         "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1687746941,
@@ -799,7 +793,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
@@ -823,7 +817,7 @@
           "parts"
         ],
         "nixpkgs": [
-          "unstable"
+          "nixpkgs"
         ],
         "rust-overlay": "rust-overlay_2"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -47,8 +47,6 @@
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
-    flake-utils.url = "github:numtide/flake-utils";
-
     emacs.url = "github:nix-community/emacs-overlay";
     emacs.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,30 +28,26 @@
     };
 
   inputs = {
-    nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     nixpkgs-insync-v3.url = "github:nixos/nixpkgs?ref=32fdc268e921994e3f38088486ddfe765d11df93";
 
     nvim.url = "github:nobbz/nobbz-vim";
 
     switcher.url = "github:nobbz/nix-switcher?ref=main";
-    switcher.inputs.nixpkgs.follows = "unstable";
+    switcher.inputs.nixpkgs.follows = "nixpkgs";
     switcher.inputs.flake-parts.follows = "parts";
 
     parts.url = "github:hercules-ci/flake-parts";
 
     programsdb.url = "github:wamserma/flake-programs-sqlite";
-    programsdb.inputs.nixpkgs.follows = "unstable";
-
-    # The following is required to make flake-parts work.
-    nixpkgs.follows = "nixpkgs-unstable";
-    unstable.follows = "nixpkgs-unstable";
+    programsdb.inputs.nixpkgs.follows = "nixpkgs";
 
     nix.url = "github:nixos/nix";
 
     nil.url = "github:oxalica/nil";
 
     home-manager.url = "github:nix-community/home-manager";
-    home-manager.inputs.nixpkgs.follows = "unstable";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
 
   inputs = {
     nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    master.url = "github:nixos/nixpkgs/master";
     nixpkgs-insync-v3.url = "github:nixos/nixpkgs?ref=32fdc268e921994e3f38088486ddfe765d11df93";
 
     nvim.url = "github:nobbz/nobbz-vim";
@@ -57,7 +56,7 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     emacs.url = "github:nix-community/emacs-overlay";
-    emacs.inputs.nixpkgs.follows = "master";
+    emacs.inputs.nixpkgs.follows = "nixpkgs";
 
     nixos-vscode-server.url = "github:msteen/nixos-vscode-server";
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,5 @@
     nixos-vscode-server.url = "github:msteen/nixos-vscode-server";
 
     sops-nix.url = "github:Mic92/sops-nix";
-
-    alejandra.url = "github:kamadorueda/alejandra/3.0.0";
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,8 @@
 
   inputs = {
     nixpkgs-2211.url = "github:nixos/nixpkgs/nixos-22.11";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    # FIXME: https://github.com/NixOS/nixpkgs/issues/317018
+    nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=9ca3f649614213b2aaf5f1e16ec06952fe4c2632";
     master.url = "github:nixos/nixpkgs/master";
     nixpkgs-insync-v3.url = "github:nixos/nixpkgs?ref=32fdc268e921994e3f38088486ddfe765d11df93";
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
     };
 
   inputs = {
-    nixpkgs-2211.url = "github:nixos/nixpkgs/nixos-22.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     master.url = "github:nixos/nixpkgs/master";
     nixpkgs-insync-v3.url = "github:nixos/nixpkgs?ref=32fdc268e921994e3f38088486ddfe765d11df93";
@@ -47,7 +46,6 @@
     # The following is required to make flake-parts work.
     nixpkgs.follows = "nixpkgs-unstable";
     unstable.follows = "nixpkgs-unstable";
-    stable.follows = "nixpkgs-2211";
 
     nix.url = "github:nixos/nix";
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
     nixpkgs-insync-v3.url = "github:nixos/nixpkgs?ref=32fdc268e921994e3f38088486ddfe765d11df93";
 
     nvim.url = "github:nobbz/nobbz-vim";
+    nvim.inputs.parts.follows = "parts";
 
     switcher.url = "github:nobbz/nix-switcher?ref=main";
     switcher.inputs.nixpkgs.follows = "nixpkgs";
@@ -43,6 +44,7 @@
     programsdb.inputs.nixpkgs.follows = "nixpkgs";
 
     nix.url = "github:nixos/nix";
+    nix.inputs.flake-parts.follows = "parts";
 
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,6 @@
 
     nix.url = "github:nixos/nix";
 
-    nil.url = "github:oxalica/nil";
-
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,7 @@
 
   inputs = {
     nixpkgs-2211.url = "github:nixos/nixpkgs/nixos-22.11";
-    # FIXME: https://github.com/NixOS/nixpkgs/issues/317018
-    nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=9ca3f649614213b2aaf5f1e16ec06952fe4c2632";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     master.url = "github:nixos/nixpkgs/master";
     nixpkgs-insync-v3.url = "github:nixos/nixpkgs?ref=32fdc268e921994e3f38088486ddfe765d11df93";
 

--- a/flake.nix
+++ b/flake.nix
@@ -45,14 +45,18 @@
 
     nix.url = "github:nixos/nix";
     nix.inputs.flake-parts.follows = "parts";
+    nix.inputs.nixpkgs.follows = "nixpkgs";
 
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     emacs.url = "github:nix-community/emacs-overlay";
     emacs.inputs.nixpkgs.follows = "nixpkgs";
+    emacs.inputs.nixpkgs-stable.follows = "nixpkgs";
 
     nixos-vscode-server.url = "github:msteen/nixos-vscode-server";
+    nixos-vscode-server.inputs.flake-utils.follows = "emacs/flake-utils";
+    nixos-vscode-server.inputs.nixpkgs.follows = "nixpkgs";
 
     sops-nix.url = "github:Mic92/sops-nix";
   };

--- a/home/configurations/nmelzer_at_mimas.nix
+++ b/home/configurations/nmelzer_at_mimas.nix
@@ -1,5 +1,4 @@
 {
-  master,
   unstable,
   self,
   ...
@@ -27,20 +26,12 @@
 
     programs.emacs.splashScreen = false;
 
-    home.packages = let
-      mpkgs = import master {
-        inherit (config.nixpkgs) config;
-        inherit (pkgs) system;
-      };
-    in
-      builtins.attrValues {
-        inherit (pkgs) keybase-gui freerdp keepassxc nix-output-monitor discord;
-        inherit (pkgs) obsidian;
-        inherit (pkgs.gnome) gnome-tweaks;
-        # https://nixpk.gs/pr-tracker.html?pr=248167
-        # ^^ once in unstable, revert this commit ^^
-        inherit (mpkgs) vscode;
-      };
+    home.packages = builtins.attrValues {
+      inherit (pkgs) keybase-gui freerdp keepassxc nix-output-monitor discord;
+      inherit (pkgs) obsidian;
+      inherit (pkgs.gnome) gnome-tweaks;
+      inherit (pkgs) vscode;
+    };
 
     programs.obs-studio.enable = true;
     programs.htop = {

--- a/home/configurations/nmelzer_at_mimas.nix
+++ b/home/configurations/nmelzer_at_mimas.nix
@@ -1,8 +1,4 @@
-{
-  unstable,
-  self,
-  ...
-}: {
+{self, ...}: {
   config,
   pkgs,
   lib,

--- a/home/modules/misc/home/default.nix
+++ b/home/modules/misc/home/default.nix
@@ -1,8 +1,4 @@
-{
-  unstable,
-  self,
-  ...
-}: {
+{self, ...}: {
   config,
   pkgs,
   lib,

--- a/home/modules/misc/home/default.nix
+++ b/home/modules/misc/home/default.nix
@@ -1,5 +1,4 @@
 {
-  nixpkgs-2211,
   unstable,
   self,
   ...

--- a/nixos/configurations/mimas.nix
+++ b/nixos/configurations/mimas.nix
@@ -4,7 +4,6 @@
 {
   self,
   unstable,
-  nixpkgs-2211,
   ...
 } @ inputs: {
   config,

--- a/nixos/configurations/mimas.nix
+++ b/nixos/configurations/mimas.nix
@@ -1,17 +1,12 @@
 # Edit this configuration file to define what should be installed on
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
-{
-  self,
-  unstable,
-  ...
-} @ inputs: {
+{self, ...} @ inputs: {
   config,
   pkgs,
   lib,
   ...
 }: let
-  upkgs = unstable.legacyPackages.x86_64-linux;
   steamPackages = ["steam" "steam-run" "steam-original" "steam-runtime"];
   printerPackages = ["hplip" "samsung-UnifiedLinuxDriver"];
 in {
@@ -217,7 +212,7 @@ in {
       enable = true;
       # storageDriver = "zfs";
       # extraOptions = "--storage-opt zfs.fsname=rpool/local/docker";
-      package = upkgs.docker;
+      package = pkgs.docker;
       extraOptions = "--dns 1.1.1.1";
     };
 

--- a/nixos/configurations/mimas.nix
+++ b/nixos/configurations/mimas.nix
@@ -35,6 +35,37 @@ in {
   nix.distributedBuilds = true;
   # nix.enabledMachines = ["enceladeus"];
 
+  nixpkgs.overlays = [
+    (final: prev: {
+      thin-provisioning-tools = prev.thin-provisioning-tools.overrideAttrs (oa: {
+        # required for compatability reasons with  =< 0.9.0
+        postInstall =
+          (oa.postInstall or "")
+          + ''
+            ln -s $out/bin/pdata_tools $out/bin/cache_check
+            ln -s $out/bin/pdata_tools $out/bin/cache_dump
+            ln -s $out/bin/pdata_tools $out/bin/cache_metadata_size
+            ln -s $out/bin/pdata_tools $out/bin/cache_repair
+            ln -s $out/bin/pdata_tools $out/bin/cache_restore
+            ln -s $out/bin/pdata_tools $out/bin/cache_writeback
+            ln -s $out/bin/pdata_tools $out/bin/era_check
+            ln -s $out/bin/pdata_tools $out/bin/era_dump
+            ln -s $out/bin/pdata_tools $out/bin/era_invalidate
+            ln -s $out/bin/pdata_tools $out/bin/era_restore
+            ln -s $out/bin/pdata_tools $out/bin/thin_check
+            ln -s $out/bin/pdata_tools $out/bin/thin_delta
+            ln -s $out/bin/pdata_tools $out/bin/thin_dump
+            ln -s $out/bin/pdata_tools $out/bin/thin_ls
+            ln -s $out/bin/pdata_tools $out/bin/thin_metadata_size
+            ln -s $out/bin/pdata_tools $out/bin/thin_repair
+            ln -s $out/bin/pdata_tools $out/bin/thin_restore
+            ln -s $out/bin/pdata_tools $out/bin/thin_rmap
+            ln -s $out/bin/pdata_tools $out/bin/thin_trim
+          '';
+      });
+    })
+  ];
+
   security.chromiumSuidSandbox.enable = true;
 
   zramSwap.enable = true;

--- a/nixos/configurations/mimas/paperless.nix
+++ b/nixos/configurations/mimas/paperless.nix
@@ -1,4 +1,4 @@
-{nixpkgs-2211, ...}: {config, ...}: {
+_: {config, ...}: {
   _file = ./paperless.nix;
 
   services.paperless = {

--- a/nixos/modules/flake.nix
+++ b/nixos/modules/flake.nix
@@ -1,6 +1,6 @@
 {
-  unstable,
   nix,
+  nixpkgs,
   programsdb,
   ...
 }: {
@@ -34,7 +34,7 @@ in {
       settings.experimental-features = ["nix-command" "flakes"];
       settings.reject-flake-config = true;
 
-      registry.nixpkgs.flake = unstable;
+      registry.nixpkgs.flake = nixpkgs;
 
       nixPath = [
         "nixpkgs=${nixpkgsPath}"
@@ -43,7 +43,7 @@ in {
     };
 
     systemd.tmpfiles.rules = [
-      "L+ ${nixpkgsPath}     - - - - ${unstable}"
+      "L+ ${nixpkgsPath}     - - - - ${nixpkgs}"
     ];
   };
 }

--- a/nixos/modules/flake.nix
+++ b/nixos/modules/flake.nix
@@ -1,6 +1,5 @@
 {
   unstable,
-  nixpkgs-2211,
   nix,
   programsdb,
   ...
@@ -12,7 +11,6 @@
 }: let
   base = "/etc/nixpkgs/channels";
   nixpkgsPath = "${base}/nixpkgs";
-  nixpkgs2211Path = "${base}/nixpkgs2211";
 in {
   _file = ./flake.nix;
 
@@ -37,18 +35,15 @@ in {
       settings.reject-flake-config = true;
 
       registry.nixpkgs.flake = unstable;
-      registry.nixpkgs2211.flake = nixpkgs-2211;
 
       nixPath = [
         "nixpkgs=${nixpkgsPath}"
-        "nixpkgs2211=${nixpkgs2211Path}"
         "/nix/var/nix/profiles/per-user/root/channels"
       ];
     };
 
     systemd.tmpfiles.rules = [
       "L+ ${nixpkgsPath}     - - - - ${unstable}"
-      "L+ ${nixpkgs2211Path} - - - - ${nixpkgs-2211}"
     ];
   };
 }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -16,25 +16,9 @@
       config.allowUnfree = true;
       config.google-chrome.enableWideVine = true;
     };
-
-    nilBase =
-      if upkgs.stdenv.isLinux
-      then inputs'.nil.packages.nil
-      else upkgs.nil;
-
-    rnil-lsp = upkgs.writeShellScriptBin "rnix-lsp" ''
-      exec ${nilBase}/bin/nil "$@"
-    '';
-
-    nil = upkgs.symlinkJoin {
-      name = "nil";
-      paths = [nilBase rnil-lsp];
-    };
   in {
     packages = lib.mkMerge [
       {
-        inherit nil;
-
         advcp = upkgs.callPackage ./advcp {};
         "dracula/konsole" = upkgs.callPackage ./dracula/konsole {};
         emacs = epkgs.emacs-unstable;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -24,8 +24,6 @@
         emacs = epkgs.emacs-unstable;
         "rofi/unicode" = upkgs.callPackage ./rofi-unicode {};
         "zx" = upkgs.nodePackages.zx;
-
-        alejandra = inputs'.alejandra.packages.default;
       }
       (lib.mkIf pkgs.stdenv.isLinux {
         inherit (inputs'.switcher.packages) switcher;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -8,7 +8,7 @@
     inputs',
     ...
   }: let
-    upkgs = inputs'.nixpkgs-unstable.legacyPackages;
+    upkgs = inputs'.nixpkgs.legacyPackages;
 
     epkgs = upkgs.extend inputs.emacs.overlay;
     chromePkgs = import inputs.nixpkgs {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -11,7 +11,7 @@
     upkgs = inputs'.nixpkgs-unstable.legacyPackages;
 
     epkgs = upkgs.extend inputs.emacs.overlay;
-    chromePkgs = import inputs.master {
+    chromePkgs = import inputs.nixpkgs {
       inherit system;
       config.allowUnfree = true;
       config.google-chrome.enableWideVine = true;

--- a/parts/auxiliary.nix
+++ b/parts/auxiliary.nix
@@ -9,7 +9,7 @@
     system,
     ...
   }: {
-    formatter = self.packages.${system}.alejandra;
+    formatter = pkgs.alejandra;
 
     apps.rotate.program = let
       sopsrotate = pkgs.writeShellScript "sops-rotate" ''
@@ -30,8 +30,7 @@
 
     devShells.default = pkgs.mkShell {
       packages = builtins.attrValues {
-        inherit (self'.packages) alejandra;
-        inherit (inputs'.nixpkgs.legacyPackages) npins sops age ssh-to-age nil;
+        inherit (pkgs) npins sops age ssh-to-age nil alejandra;
       };
     };
   };

--- a/parts/auxiliary.nix
+++ b/parts/auxiliary.nix
@@ -30,8 +30,8 @@
 
     devShells.default = pkgs.mkShell {
       packages = builtins.attrValues {
-        inherit (self'.packages) nil alejandra;
-        inherit (inputs'.nixpkgs.legacyPackages) npins sops age ssh-to-age;
+        inherit (self'.packages) alejandra;
+        inherit (inputs'.nixpkgs.legacyPackages) npins sops age ssh-to-age nil;
       };
     };
   };

--- a/parts/auxiliary.nix
+++ b/parts/auxiliary.nix
@@ -31,7 +31,7 @@
     devShells.default = pkgs.mkShell {
       packages = builtins.attrValues {
         inherit (self'.packages) nil alejandra;
-        inherit (inputs'.unstable.legacyPackages) npins sops age ssh-to-age;
+        inherit (inputs'.nixpkgs.legacyPackages) npins sops age ssh-to-age;
       };
     };
   };


### PR DESCRIPTION
- **pin nixpkgs to a known to boot version**
- **'fix' thin-provisioning-tools for now**
- **back 2 nixos unstable**
- **remove remaining and mostly unused stable input (from 18 months ago)**
- **remove master input**
- **remove aliases for nixpkgs**
- **use nil from nixpkgs**
- **remove unused FU input…**
- **use alejandra from nixpkgs**
- **use follows to remove numbers of 'flake-parts'**
- **more thining out transient inputs via follows**
