### PR TITLE
move HMs stateVersion to individual entrypoints

### DIFF
--- a/home/configurations/nmelzer_at_mimas.nix
+++ b/home/configurations/nmelzer_at_mimas.nix
@@ -123,7 +123,6 @@
         targets = ["nobbz-hetzner"]
       '';
   };
-  # environment.pathsToLink = [ "/share/zsh" ];
-}
-# /nix/store/7skqa8vxfydq7w3cix55ffvkmjb3b5da-python-2.7.18
 
+  home.stateVersion = "20.09";
+}

--- a/home/configurations/nmelzer_at_phoebe.nix
+++ b/home/configurations/nmelzer_at_phoebe.nix
@@ -87,4 +87,6 @@ in {
       user = "nmelzer";
     });
   };
+
+  home.stateVersion = "20.09";
 }

--- a/home/modules/misc/home/default.nix
+++ b/home/modules/misc/home/default.nix
@@ -39,7 +39,5 @@ in {
         exec ${p.timewarrior}/bin/timew "$@"
       '')
     ];
-
-    stateVersion = "20.09";
   };
 }


### PR DESCRIPTION
FIX #407 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added `home.stateVersion = "20.09"` to user configurations for Mimas and Phoebe systems
	- Removed explicit `stateVersion` definition from default home module configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->