### PR TITLE
change font for ghostty

### DIFF
--- a/home/modules/programs/ghostty/default.nix
+++ b/home/modules/programs/ghostty/default.nix
@@ -2,7 +2,7 @@ _: {pkgs, ...}: {
   xdg.configFile."ghostty/config".text =
     # toml
     ''
-      font-family = "Cascadia Mono"
+      font-family = "Departure Mono"
 
       ## uncomment once keybindings have been set to something I am familiar
       ## with. The bar contains the menu, which I need for splits for now…


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the application’s default font to "Departure Mono", providing a refreshed typographic appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->