### PR TITLE
fix-neovide

### DIFF
--- a/home/modules/profiles/base/default.nix
+++ b/home/modules/profiles/base/default.nix
@@ -105,7 +105,7 @@ in {
         if cfg.needsGL
         then
           pkgs.writeShellScriptBin nvim.packages.x86_64-linux.neovide.meta.mainProgram ''
-            exec ${lib.getExe nix-gl.packages.x86_64-linux.nixGLIntel} ${lib.getExe nvim.packages.x86_64-linux.neovide}
+            exec ${lib.getExe nix-gl.packages.x86_64-linux.nixGLIntel} ${lib.getExe nvim.packages.x86_64-linux.neovide} "$@"
           ''
         else nvim.packages.x86_64-linux.neovide;
     in


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where command-line arguments were not passed to Neovide when using the wrapper with `needsGL` enabled. All arguments are now correctly forwarded to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->