### PR TITLE
Enable the PAM for i3lock/i3lock-color

### DIFF
--- a/nixos/configurations/mimas.nix
+++ b/nixos/configurations/mimas.nix
@@ -19,6 +19,9 @@ in {
 
   services.tailscale.enable = true;
 
+  security.pam.services.i3lock.enable = true;
+  security.pam.services.i3lock-color.enable = true;
+
   sops.age.sshKeyPaths = ["/etc/ssh/ssh_host_ed25519_key"];
   sops.defaultSopsFile = "${self}/secrets/mimas/default.yaml";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled PAM authentication support for i3lock and i3lock-color, enhancing login security options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->