### PR TITLE
enable jujutsu

### DIFF
--- a/home/modules/profiles/development/default.nix
+++ b/home/modules/profiles/development/default.nix
@@ -13,6 +13,18 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    programs.jujutsu = {
+      enable = true;
+      settings = {
+        user = {
+          name = config.programs.git.userName;
+          email = config.programs.git.userEmail;
+        };
+
+        ui.diff.tool = [config.programs.git.extraConfig.diff.external "$left" "$right"];
+      };
+    };
+
     programs.gh.enable = true;
     programs.git = {
       enable = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled the jujutsu program in the development profile with automatic configuration.
	- Jujutsu now inherits Git user name and email settings.
	- Jujutsu's diff tool is set to match the external diff tool defined in Git settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->